### PR TITLE
Use strings as keys

### DIFF
--- a/lib/emque/consuming/router.rb
+++ b/lib/emque/consuming/router.rb
@@ -56,11 +56,11 @@ module Emque
         end
 
         def map(map)
-          mapping.merge!(map.symbolize_keys)
+          mapping.merge!(map)
         end
 
         def route(type)
-          mapping[type.to_sym]
+          mapping[type]
         end
 
         private

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+require "emque/consuming/consumer"
+require "emque/consuming/consumer/common"
+
+describe Emque::Consuming::Router do
+  describe "#topic" do
+    it "uses strings as mapping keys" do
+      router = Emque::Consuming::Router.new
+      mappings = router.topic("events" => "EventsConsumer") do
+        map "events.new" => "new_event"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use strings to avoid need to use symbolize_keys, thus further removing need for ActiveSupport