### PR TITLE
Use prefetch to limit unacknowledged workers

### DIFF
--- a/lib/emque/consuming/adapters/rabbit_mq.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq.rb
@@ -3,7 +3,7 @@ module Emque
     module Adapters
       module RabbitMq
         def self.default_options
-          {:url => "amqp://guest:guest@localhost:5672"}
+          {:url => "amqp://guest:guest@localhost:5672", :prefetch => nil}
         end
 
         def self.load
@@ -18,4 +18,3 @@ module Emque
     end
   end
 end
-

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -25,6 +25,7 @@ module Emque
             #        a new channel in each worker.
             # https://github.com/jhbabon/amqp-celluloid/blob/master/lib/consumer.rb
             self.channel = connection.create_channel
+            channel.prefetch(config.adapter.options[:prefetch]) if config.adapter.options[:prefetch]
 
             self.queue =
               channel


### PR DESCRIPTION
Limit the number of unacknowledged messages a worker can take.

https://www.rabbitmq.com/consumer-prefetch.html
http://rubybunny.info/articles/queues.html#qos__prefetching_messages