### PR TITLE
Fixes #36 allowing a consumer to declare auto-deleteable queues

### DIFF
--- a/lib/emque/consuming/adapters/rabbit_mq.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq.rb
@@ -3,7 +3,12 @@ module Emque
     module Adapters
       module RabbitMq
         def self.default_options
-          {:url => "amqp://guest:guest@localhost:5672", :prefetch => nil}
+          {
+            :url => "amqp://guest:guest@localhost:5672",
+            :prefetch => nil,
+            :durable => true,
+            :auto_delete => false
+          }
         end
 
         def self.load

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -31,8 +31,8 @@ module Emque
               channel
                 .queue(
                   "#{config.app_name}.#{topic}",
-                  :durable => true,
-                  :auto_delete => false
+                  :durable => config.adapter.options[:durable],
+                  :auto_delete => config.adapter.options[:auto_delete]
                 )
                 .bind(
                   channel.fanout(topic, :durable => true, :auto_delete => false)


### PR DESCRIPTION
Allow for queues that will not queue messages while the service is down.

### Use Case

A consuming service that tracks messages and records stats with StatsD. StatsD has no concept of time, so if the service were to be down and have messages continue to be queued up, these would be processed as a huge spike in StatsD when the service comes up again.